### PR TITLE
Consistent naming for cluster contexts

### DIFF
--- a/multicloud-deployment/labs/6.md
+++ b/multicloud-deployment/labs/6.md
@@ -48,8 +48,7 @@ git clone https://github.com/open-cluster-management/labs.git
 2. Deploy the application.
 
 ```
-cd assets/app/acm
-oc --context hub apply -f .
+oc --context hub apply -f labs/multicloud-deployment/acm
 ```
 
 3. Explore the spoke clusters and create the route. You will notice that there are now application projects in all of the environments.

--- a/multicloud-deployment/labs/6.md
+++ b/multicloud-deployment/labs/6.md
@@ -26,15 +26,15 @@ Download all of your kubeconfig files for each spoke from ACM. If you don't know
 1. Explore the spoke clusters. You will notice that there are no application projects in any of the environments.
 
 ``` 
-oc config use aws-admin
+oc config use aws-spoke
 oc config current-context
 oc get projects
 
-oc config use gcp-admin
+oc config use gcp-spoke
 oc config current-context
 oc get projects
 
-oc config use azure-admin
+oc config use azure-spoke
 oc config current-context
 oc get projects
 ``` 
@@ -55,20 +55,20 @@ oc --context hub apply -f .
 3. Explore the spoke clusters and create the route. You will notice that there are now application projects in all of the environments.
 
 ``` 
-oc --context aws-admin get projects | grep apache
-oc --context aws-admin project aws-apache-test
-oc --context aws-admin expose service apache-service
-oc --context aws-admin get all
+oc --context aws-spoke get projects | grep apache
+oc --context aws-spoke project aws-apache-test
+oc --context aws-spoke expose service apache-service
+oc --context aws-spoke get all
 
-oc --context gcp-admin get projects | grep apache
-oc --context gcp-admin project gcp-apache-test
-oc --context gcp-admin expose service apache-service
-oc --context gcp-admin get all
+oc --context gcp-spoke get projects | grep apache
+oc --context gcp-spoke project gcp-apache-test
+oc --context gcp-spoke expose service apache-service
+oc --context gcp-spoke get all
 
-oc --context azure-admin get projects | grep apache
-oc --context azure-admin project azure-apache-test
-oc --context azure-admin expose service apache-service
-oc --context azure-admin get all
+oc --context azure-spoke get projects | grep apache
+oc --context azure-spoke project azure-apache-test
+oc --context azure-spoke expose service apache-service
+oc --context azure-spoke get all
 ``` 
 
 


### PR DESCRIPTION
Fixes #13 in favor of `-spoke` naming