### PR TITLE
Single namespace fix for channel references

### DIFF
--- a/multicloud-deployment/acm/00_azure_namespace.yaml
+++ b/multicloud-deployment/acm/00_azure_namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: azure-apache-test

--- a/multicloud-deployment/acm/00_gcp_namespace.yaml
+++ b/multicloud-deployment/acm/00_gcp_namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: gcp-apache-test

--- a/multicloud-deployment/acm/00_namespace.yaml
+++ b/multicloud-deployment/acm/00_namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: aws-apache-test
+  name: apache-test

--- a/multicloud-deployment/acm/01_azure_channel.yaml
+++ b/multicloud-deployment/acm/01_azure_channel.yaml
@@ -1,8 +1,0 @@
-apiVersion: apps.open-cluster-management.io/v1
-kind: Channel
-metadata:
-  name: azure-apache-channel
-  namespace: azure-apache-test
-spec:
-  type: GitHub
-  pathname: https://github.com/scollier/acm-app.git

--- a/multicloud-deployment/acm/01_channel.yaml
+++ b/multicloud-deployment/acm/01_channel.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
-  name: aws-apache-channel
-  namespace: aws-apache-test
+  name: apache-channel
+  namespace: apache-test
 spec:
   type: GitHub
   pathname: https://github.com/scollier/acm-app.git

--- a/multicloud-deployment/acm/01_gcp_channel.yaml
+++ b/multicloud-deployment/acm/01_gcp_channel.yaml
@@ -1,8 +1,0 @@
-apiVersion: apps.open-cluster-management.io/v1
-kind: Channel
-metadata:
-  name: gcp-apache-channel
-  namespace: gcp-apache-test
-spec:
-  type: GitHub
-  pathname: https://github.com/scollier/acm-app.git

--- a/multicloud-deployment/acm/02_aws_placement_rule.yaml
+++ b/multicloud-deployment/acm/02_aws_placement_rule.yaml
@@ -2,7 +2,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: aws-clusters
-  namespace: aws-apache-test
+  namespace: apache-test
 spec:
   clusterConditions:
    - type: OK

--- a/multicloud-deployment/acm/02_azure_placement_rule.yaml
+++ b/multicloud-deployment/acm/02_azure_placement_rule.yaml
@@ -2,7 +2,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: azure-clusters
-  namespace: azure-apache-test
+  namespace: apache-test
 spec:
   clusterConditions:
    - type: OK

--- a/multicloud-deployment/acm/02_azure_placement_rule.yaml
+++ b/multicloud-deployment/acm/02_azure_placement_rule.yaml
@@ -9,5 +9,5 @@ spec:
   clusterSelector:
     matchExpressions: []
     matchLabels:
-      cloud: "Microsoft"
+      cloud: "Azure"
   clusterReplicas: 1

--- a/multicloud-deployment/acm/02_gcp_placement_rule.yaml
+++ b/multicloud-deployment/acm/02_gcp_placement_rule.yaml
@@ -2,7 +2,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: gcp-clusters
-  namespace: gcp-apache-test
+  namespace: apache-test
 spec:
   clusterConditions:
    - type: OK

--- a/multicloud-deployment/acm/03_aws_subscription.yaml
+++ b/multicloud-deployment/acm/03_aws_subscription.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     cloud: Amazon
   annotations:
-    apps.open-cluster-management.io/github-path: kustomize-app
+    apps.open-cluster-management.io/github-path: kustomize-app/overlays/aws
+    apps.open-cluster-management.io/github-branch: cwilkers
 spec:
   channel: apache-test/apache-channel
   placement:

--- a/multicloud-deployment/acm/03_aws_subscription.yaml
+++ b/multicloud-deployment/acm/03_aws_subscription.yaml
@@ -2,13 +2,13 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   name: aws-apache-subscription
-  namespace: aws-apache-test
+  namespace: apache-test
   labels:
     cloud: Amazon
   annotations:
     apps.open-cluster-management.io/github-path: kustomize-app
 spec:
-  channel: aws-apache-test/apache-channel
+  channel: apache-test/apache-channel
   placement:
     placementRef:
       kind: PlacementRule

--- a/multicloud-deployment/acm/03_azure_subscription.yaml
+++ b/multicloud-deployment/acm/03_azure_subscription.yaml
@@ -4,9 +4,10 @@ metadata:
   name: azure-apache-subscription
   namespace: apache-test
   labels:
-    cloud: Google
+    cloud: Azure
   annotations:
-    apps.open-cluster-management.io/github-path: kustomize-app
+    apps.open-cluster-management.io/github-path: kustomize-app/overlays/azure
+    apps.open-cluster-management.io/github-branch: cwilkers
 spec:
   channel: apache-test/apache-channel
   placement:

--- a/multicloud-deployment/acm/03_azure_subscription.yaml
+++ b/multicloud-deployment/acm/03_azure_subscription.yaml
@@ -2,13 +2,13 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   name: azure-apache-subscription
-  namespace: azure-apache-test
+  namespace: apache-test
   labels:
     cloud: Google
   annotations:
     apps.open-cluster-management.io/github-path: kustomize-app
 spec:
-  channel: azure-apache-test/apache-channel
+  channel: apache-test/apache-channel
   placement:
     placementRef:
       kind: PlacementRule

--- a/multicloud-deployment/acm/03_gcp_subscription.yaml
+++ b/multicloud-deployment/acm/03_gcp_subscription.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     cloud: Google
   annotations:
-    apps.open-cluster-management.io/github-path: kustomize-app
+    apps.open-cluster-management.io/github-path: kustomize-app/overlays/gcp
+    apps.open-cluster-management.io/github-branch: cwilkers
 spec:
   channel: apache-test/apache-channel
   placement:

--- a/multicloud-deployment/acm/03_gcp_subscription.yaml
+++ b/multicloud-deployment/acm/03_gcp_subscription.yaml
@@ -2,13 +2,13 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   name: gcp-apache-subscription
-  namespace: gcp-apache-test
+  namespace: apache-test
   labels:
     cloud: Google
   annotations:
     apps.open-cluster-management.io/github-path: kustomize-app
 spec:
-  channel: gcp-apache-test/apache-channel
+  channel: apache-test/apache-channel
   placement:
     placementRef:
       kind: PlacementRule

--- a/multicloud-deployment/labs/6.md
+++ b/multicloud-deployment/labs/6.md
@@ -53,21 +53,21 @@ oc --context hub apply -f labs/multicloud-deployment/acm
 
 3. Explore the spoke clusters and create the route. You will notice that there are now application projects in all of the environments.
 
-``` 
+```bash 
 oc --context aws-spoke get projects | grep apache
-oc --context aws-spoke project aws-apache-test
-oc --context aws-spoke expose service apache-service
-oc --context aws-spoke get all
+oc --context aws-spoke -n apache-test get services
+oc --context aws-spoke -n apache-test expose service apache-service
+oc --context aws-spoke -n apache-test get all
 
 oc --context gcp-spoke get projects | grep apache
-oc --context gcp-spoke project gcp-apache-test
-oc --context gcp-spoke expose service apache-service
-oc --context gcp-spoke get all
+oc --context gcp-spoke -n apache-test get services
+oc --context gcp-spoke -n apache-test expose service apache-service
+oc --context gcp-spoke -n apache-test get all
 
 oc --context azure-spoke get projects | grep apache
-oc --context azure-spoke project azure-apache-test
-oc --context azure-spoke expose service apache-service
-oc --context azure-spoke get all
+oc --context azure-spoke -n apache-test get services
+oc --context azure-spoke -n apache-test expose service apache-service
+oc --context azure-spoke -n apache-test get all
 ``` 
 
 

--- a/multicloud-deployment/labs/6.md
+++ b/multicloud-deployment/labs/6.md
@@ -74,9 +74,9 @@ oc --context azure-spoke get all
 4. Confirm Application Access by making a note of the routes for each cluster above and accessing them directly. Also, they will be used for the configuration of HAProxy. Make sure to replace the DNS name below with your routes.
 
 ```
-curl http://apache-service-aws-apache-test.apps.aws-spoke-1.<engineer>.sysdeseng.com
-curl http://apache-service-gcp-apache-test.apps.gcp-spoke-1.<engineer>.sysdeseng.com
-curl http://apache-service-azure-apache-test.apps.azure-spoke-1.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.aws-spoke-1.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.gcp-spoke-1.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.azure-spoke-1.<engineer>.sysdeseng.com
 ```
 
 5. Patch the OpenShift route on each cluster to reflect the DNS name of the HAProxy instance so that OpenShift can interpret the header corretly.

--- a/multicloud-deployment/labs/6.md
+++ b/multicloud-deployment/labs/6.md
@@ -70,13 +70,12 @@ oc --context azure-spoke -n apache-test expose service apache-service
 oc --context azure-spoke -n apache-test get all
 ``` 
 
-
 4. Confirm Application Access by making a note of the routes for each cluster above and accessing them directly. Also, they will be used for the configuration of HAProxy. Make sure to replace the DNS name below with your routes.
 
 ```
 curl http://apache-service-apache-test.apps.aws-spoke-1.<engineer>.sysdeseng.com
-curl http://apache-service-apache-test.apps.gcp-spoke-1.<engineer>.sysdeseng.com
-curl http://apache-service-apache-test.apps.azure-spoke-1.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.gcp-spoke-1.<engineer>-gcp.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.azure-spoke-1.<engineer>-azure.<engineer>.sysdeseng.com
 ```
 
 5. Patch the OpenShift route on each cluster to reflect the DNS name of the HAProxy instance so that OpenShift can interpret the header corretly.
@@ -84,9 +83,9 @@ curl http://apache-service-apache-test.apps.azure-spoke-1.<engineer>.sysdeseng.c
 **NOTE:** This should be done in the git repository. However, for now, for the sake of time, we are patching the routes directly.
 
 ```
-oc patch route apache-service -n gcp-apache-test -p '{"spec":{"host": "haproxy.<engineer>.sysdeseng.com"}}'
-oc patch route apache-service -n aws-apache-test -p '{"spec":{"host": "haproxy.<engineer>.sysdeseng.com"}}'
-oc patch route apache-service -n azure-apache-test -p '{"spec":{"host": "haproxy.<engineer>.sysdeseng.com"}}'
+oc --context aws-spoke -n apache-test patch route apache-service -p '{"spec":{"host": "haproxy.<engineer>.sysdeseng.com"}}'
+oc --context gcp-spoke -n apache-test patch route apache-service -p '{"spec":{"host": "haproxy.<engineer>.sysdeseng.com"}}'
+oc --context azure-spoke -n apache-test patch route apache-service -p '{"spec":{"host": "haproxy.<engineer>.sysdeseng.com"}}'
 ```
 
 ---


### PR DESCRIPTION
- Reduce all clouds to a single namespace
- Use full kustomize path to each cloud's overlay
- Fix Azure nitpicks
- Update doc to agree with single ns