### PR TITLE
Haproxy fixes

### DIFF
--- a/multicloud-deployment/haproxy/haproxy.cfg
+++ b/multicloud-deployment/haproxy/haproxy.cfg
@@ -40,6 +40,6 @@ frontend main
 
 backend app
     balance                roundrobin
-    server s1 apache-service-gcp-apache-test.apps.gcp-spoke-1.scollier-gcp.scollier.sysdeseng.com:80 resolvers mydns
-    server s2 apache-service-aws-apache-test.apps.aws-spoke-1.scollier.sysdeseng.com:80 resolvers mydns
-    server s3 apache-service-azure-apache-test.apps.aws-spoke-1.scollier.sysdeseng.com:80 resolvers mydns
+    server s1 apache-service-apache-test.apps.gcp-spoke-1.ENGINEER-gcp.ENGINEER.sysdeseng.com:80 resolvers mydns
+    server s2 apache-service-apache-test.apps.aws-spoke-1.ENGINEER.sysdeseng.com:80 resolvers mydns
+    server s3 apache-service-apache-test.apps.azure-spoke-1.ENGINEER-azure.ENGINEER.sysdeseng.com:80 resolvers mydns

--- a/multicloud-deployment/haproxy/haproxy.cfg
+++ b/multicloud-deployment/haproxy/haproxy.cfg
@@ -40,6 +40,6 @@ frontend main
 
 backend app
     balance                roundrobin
-    server s1 apache-service-apache-test.apps.gcp-spoke-1.ENGINEER-gcp.ENGINEER.sysdeseng.com:80 resolvers mydns
-    server s2 apache-service-apache-test.apps.aws-spoke-1.ENGINEER.sysdeseng.com:80 resolvers mydns
-    server s3 apache-service-apache-test.apps.azure-spoke-1.ENGINEER-azure.ENGINEER.sysdeseng.com:80 resolvers mydns
+    server s1 apache-service-apache-test.apps.ENGINEER-gcp-spoke-1.ENGINEER-gcp.ENGINEER.sysdeseng.com:80 resolvers mydns
+    server s2 apache-service-apache-test.apps.ENGINEER-aws-spoke-1.ENGINEER.sysdeseng.com:80 resolvers mydns
+    server s3 apache-service-apache-test.apps.ENGINEER-azure-spoke-1.ENGINEER-azure.ENGINEER.sysdeseng.com:80 resolvers mydns

--- a/multicloud-deployment/labs/6.md
+++ b/multicloud-deployment/labs/6.md
@@ -73,9 +73,9 @@ oc --context azure-spoke -n apache-test get all
 4. Confirm Application Access by making a note of the routes for each cluster above and accessing them directly. Also, they will be used for the configuration of HAProxy. Make sure to replace the DNS name below with your routes.
 
 ```
-curl http://apache-service-apache-test.apps.aws-spoke-1.<engineer>.sysdeseng.com
-curl http://apache-service-apache-test.apps.gcp-spoke-1.<engineer>-gcp.<engineer>.sysdeseng.com
-curl http://apache-service-apache-test.apps.azure-spoke-1.<engineer>-azure.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.<engineer>-aws-spoke-1.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.<engineer>-gcp-spoke-1.<engineer>-gcp.<engineer>.sysdeseng.com
+curl http://apache-service-apache-test.apps.<engineer>-azure-spoke-1.<engineer>-azure.<engineer>.sysdeseng.com
 ```
 
 5. Patch the OpenShift route on each cluster to reflect the DNS name of the HAProxy instance so that OpenShift can interpret the header corretly.

--- a/multicloud-deployment/labs/7.md
+++ b/multicloud-deployment/labs/7.md
@@ -13,7 +13,7 @@ Here the HAProxy load balancer will be set up to provide a single point of entry
 
 1. Download the following [HAProxy file](../haproxy/haproxy.cfg).
 
-2. Change the bottom of the HAProxy configuration file to reflect the correct DNS names of the routes you have on each cluster for the new applications that were deployed.
+2. Change the bottom of the HAProxy configuration file to reflect the correct DNS names of the routes you have on each cluster for the new applications that were deployed. Following the naming suggestions laid out here, replace the string ENGINEER with your own identifier. 
 
 3. Confirm the HAProxy file is valid.
 


### PR DESCRIPTION
- Make s/scollier/ENGINEER/ for easier visibility and sed magic
- Update hostnames, since ENGINEER is used for cluster name, sub-sub domain, and sub-domain
- Distinguish azure (was aws)